### PR TITLE
RandomPoolRouter and RandomGroupRouter

### DIFF
--- a/actor/randomrouter.go
+++ b/actor/randomrouter.go
@@ -1,0 +1,69 @@
+package actor
+
+import "math/rand"
+
+type RandomGroupRouter struct {
+	routees []*PID
+}
+
+type RandomPoolRouter struct {
+	poolSize int
+}
+
+type RandomRouterState struct {
+	routees []*PID
+	config  RouterConfig
+}
+
+func (state *RandomRouterState) SetRoutees(routees []*PID) {
+	state.routees = routees
+}
+
+func NewRandomPool(poolSize int) PoolRouterConfig {
+	return &RandomPoolRouter{poolSize: poolSize}
+}
+
+func NewRandomGroup(routees ...*PID) GroupRouterConfig {
+	return &RandomGroupRouter{routees: routees}
+}
+
+func (state *RandomRouterState) Route(message interface{}) {
+	pid := randomRoutee(state.routees)
+	pid.Tell(message)
+}
+
+func (config *RandomPoolRouter) Create() RouterState {
+	return &RandomRouterState{
+		config: config,
+	}
+}
+
+func (config *RandomGroupRouter) Create() RouterState {
+	return &RandomRouterState{
+		config: config,
+	}
+}
+
+func (config *RandomPoolRouter) PoolRouter()   {}
+func (config *RandomGroupRouter) GroupRouter() {}
+
+func randomRoutee(routees []*PID) *PID {
+	routee := routees[rand.Intn(len(routees))]
+	return routee
+}
+
+func (config *RandomGroupRouter) OnStarted(context Context, props Props, router RouterState) {
+	for _, r := range config.routees {
+		context.Watch(r)
+	}
+	router.SetRoutees(config.routees)
+}
+
+func (config *RandomPoolRouter) OnStarted(context Context, props Props, router RouterState) {
+	routees := make([]*PID, config.poolSize)
+	for i := 0; i < config.poolSize; i++ {
+		pid := context.Spawn(props)
+		routees[i] = pid
+	}
+	router.SetRoutees(routees)
+}

--- a/examples/routing/main.go
+++ b/examples/routing/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"time"
 
 	"github.com/rogeralsing/gam/actor"
 	"github.com/rogeralsing/goconsole"
@@ -16,11 +17,18 @@ func main() {
 			log.Printf("%v got message %d", context.Self(), context.Message().(myMessage).i)
 		}
 	}
+	log.Println("Round robin routing:")
 	props := actor.FromFunc(act).WithPoolRouter(actor.NewRoundRobinPool(10))
 	pid := actor.Spawn(props)
 	for i := 0; i < 10; i++ {
 		pid.Tell(myMessage{i})
 	}
-
+	time.Sleep(1 * time.Second)
+	log.Println("Random routing:")
+	props = actor.FromFunc(act).WithPoolRouter(actor.NewRandomPool(10))
+	pid = actor.Spawn(props)
+	for i := 0; i < 10; i++ {
+		pid.Tell(myMessage{i})
+	}
 	console.ReadLine()
 }

--- a/examples/routing/main.go
+++ b/examples/routing/main.go
@@ -18,14 +18,14 @@ func main() {
 		}
 	}
 	log.Println("Round robin routing:")
-	props := actor.FromFunc(act).WithPoolRouter(actor.NewRoundRobinPool(10))
+	props := actor.FromFunc(act).WithPoolRouter(actor.NewRoundRobinPool(5))
 	pid := actor.Spawn(props)
 	for i := 0; i < 10; i++ {
 		pid.Tell(myMessage{i})
 	}
 	time.Sleep(1 * time.Second)
 	log.Println("Random routing:")
-	props = actor.FromFunc(act).WithPoolRouter(actor.NewRandomPool(10))
+	props = actor.FromFunc(act).WithPoolRouter(actor.NewRandomPool(5))
 	pid = actor.Spawn(props)
 	for i := 0; i < 10; i++ {
 		pid.Tell(myMessage{i})

--- a/examples/routing/main.go
+++ b/examples/routing/main.go
@@ -7,19 +7,19 @@ import (
 	"github.com/rogeralsing/goconsole"
 )
 
-type myMessage struct{}
+type myMessage struct{ i int }
 
 func main() {
 	act := func(context actor.Context) {
 		switch context.Message().(type) {
 		case myMessage:
-			log.Printf("%v got message", context.Self())
+			log.Printf("%v got message %d", context.Self(), context.Message().(myMessage).i)
 		}
 	}
 	props := actor.FromFunc(act).WithPoolRouter(actor.NewRoundRobinPool(10))
 	pid := actor.Spawn(props)
 	for i := 0; i < 10; i++ {
-		pid.Tell(myMessage{})
+		pid.Tell(myMessage{i})
 	}
 
 	console.ReadLine()


### PR DESCRIPTION
This series of patches adds a **RandomPoolRouter** and **RandomGroupRouter** as suggested in #7.
Besides adding the two new routers, this series improves the output of the routing example tests and adds an example for **RandomPoolRouter**.

At the end of this stack of patches, running the example prints:

```
2016/07/17 15:47:57 Round robin routing:
2016/07/17 15:47:57 Host:"nonhost" Id:"5"  got message 1
2016/07/17 15:47:57 Host:"nonhost" Id:"3"  got message 4
2016/07/17 15:47:57 Host:"nonhost" Id:"3"  got message 9
2016/07/17 15:47:57 Host:"nonhost" Id:"5"  got message 6
2016/07/17 15:47:57 Host:"nonhost" Id:"7"  got message 3
2016/07/17 15:47:57 Host:"nonhost" Id:"7"  got message 8
2016/07/17 15:47:57 Host:"nonhost" Id:"4"  got message 0
2016/07/17 15:47:57 Host:"nonhost" Id:"4"  got message 5
2016/07/17 15:47:57 Host:"nonhost" Id:"6"  got message 2
2016/07/17 15:47:57 Host:"nonhost" Id:"6"  got message 7
2016/07/17 15:47:58 Random routing:
2016/07/17 15:47:58 Host:"nonhost" Id:"c"  got message 0
2016/07/17 15:47:58 Host:"nonhost" Id:"c"  got message 4
2016/07/17 15:47:58 Host:"nonhost" Id:"f"  got message 3
2016/07/17 15:47:58 Host:"nonhost" Id:"e"  got message 5
2016/07/17 15:47:58 Host:"nonhost" Id:"c"  got message 8
2016/07/17 15:47:58 Host:"nonhost" Id:"b"  got message 6
2016/07/17 15:47:58 Host:"nonhost" Id:"b"  got message 7
2016/07/17 15:47:58 Host:"nonhost" Id:"b"  got message 9
2016/07/17 15:47:58 Host:"nonhost" Id:"d"  got message 1
2016/07/17 15:47:58 Host:"nonhost" Id:"d"  got message 2


```